### PR TITLE
[SPARKL-35]

### DIFF
--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/InferedKettleOutput.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/InferedKettleOutput.java
@@ -19,15 +19,9 @@ import javax.servlet.http.HttpServletResponse;
 
 public class InferedKettleOutput extends KettleOutput {
 
-  private String mimeType;
-  private String attachmentName;
+  public InferedKettleOutput( HttpServletResponse response, Configuration configuration ) {
+    super( response, configuration );
 
-
-  public InferedKettleOutput( HttpServletResponse response, boolean download, String mimeType, String attachmentName ) {
-    super( response, download );
-
-    this.mimeType = mimeType;
-    this.attachmentName = attachmentName;
   }
 
   /**
@@ -46,17 +40,17 @@ public class InferedKettleOutput extends KettleOutput {
 
     IKettleOutput kettleOutput;
     if ( result.getFiles().size() > 0 ) {
-      kettleOutput = new ResultFilesKettleOutput( this.getResponse(), this.getDownload(), this.mimeType, this.attachmentName );
+      kettleOutput = new ResultFilesKettleOutput( this.getResponse(), this.getConfiguration() );
 
     } else if ( result.getKettleType() == KettleResult.KettleType.JOB ) {
-      kettleOutput = new ResultOnlyKettleOutput( this.getResponse(), this.getDownload() );
+      kettleOutput = new ResultOnlyKettleOutput( this.getResponse(), this.getConfiguration() );
 
     } else if ( result.getRows().size() == 1
       && result.getRows().get( 0 ).getRowMeta().getValueMetaList().size() == 1 ) {
-      kettleOutput = new SingleCellKettleOutput( this.getResponse(), this.getDownload(), this.mimeType, this.attachmentName );
+      kettleOutput = new SingleCellKettleOutput( this.getResponse(), this.getConfiguration() );
 
     } else {
-      kettleOutput = new JsonKettleOutput( this.getResponse(), this.getDownload() );
+      kettleOutput = new JsonKettleOutput( this.getResponse(), this.getConfiguration() );
     }
 
     kettleOutput.processResult( result );

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/JsonKettleOutput.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/JsonKettleOutput.java
@@ -17,7 +17,9 @@ package pt.webdetails.cpk.elements.impl.kettleoutputs;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMetaInterface;
+import pt.webdetails.cpf.utils.MimeTypes;
 import pt.webdetails.cpk.elements.impl.KettleResult;
+import pt.webdetails.cpk.utils.CpkUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -27,8 +29,10 @@ import java.util.Collection;
 
 public class JsonKettleOutput extends KettleOutput {
 
-  public JsonKettleOutput( HttpServletResponse response, boolean download ) {
-    super( response, download );
+  public JsonKettleOutput( HttpServletResponse response, Configuration configuration ) {
+    super( response, configuration );
+
+    configuration.setMimeType( MimeTypes.JSON );
   }
 
   @Override
@@ -49,6 +53,7 @@ public class JsonKettleOutput extends KettleOutput {
     RowsJson rowsJson = new RowsJson( rows, rowMeta );
 
     try {
+      CpkUtils.setResponseHeaders( this.getResponse(), this.getConfiguration().getMimeType() );
       ObjectMapper mapper = new ObjectMapper();
       mapper.writeValue( this.getOut(), rowsJson );
     } catch ( IOException ex ) {

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/KettleOutput.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/KettleOutput.java
@@ -22,19 +22,83 @@ import java.io.OutputStream;
 
 public abstract class KettleOutput implements IKettleOutput {
 
+  public static final class Configuration implements Cloneable {
+
+    // TODO: change to enum
+    private String outputType;
+    private String mimeType;
+    private String attachmentName;
+    private boolean sendResultAsAttachment = false;
+
+    /**
+     *
+     * @return The type of output that is to be returned.
+     */
+    public String getOutputType() { return outputType; }
+    public Configuration setOutputType( String outputType ) {
+      this.outputType = outputType;
+      return this;
+    }
+
+    /**
+     *
+     * @return If the result is to be sent as an attachment of the response.
+     */
+    public boolean getSendResultAsAttachment() { return this.sendResultAsAttachment; }
+    public Configuration setSendResultAsAttachment( boolean sendResultAsAttachment ) {
+      this.sendResultAsAttachment = sendResultAsAttachment;
+      return this;
+    }
+
+    /**
+     *
+     * @return The name of the attachment to use when sending the result as an attachment.
+     */
+    public String getAttachmentName() { return attachmentName; }
+    public Configuration setAttachmentName( String attachmentName ) {
+      this.attachmentName = attachmentName;
+      return this;
+    }
+
+    /**
+     *
+     * @return The mime type to be used when sending result as an attachment.
+     */
+    public String getMimeType() { return mimeType; }
+    public Configuration setMimeType( String mimeType ) {
+      this.mimeType = mimeType;
+      return this;
+    }
+
+    @Override
+    public Configuration clone() {
+      Configuration clone = new Configuration();
+      clone
+        .setAttachmentName( this.attachmentName )
+        .setMimeType( this.mimeType )
+        .setSendResultAsAttachment( this.sendResultAsAttachment )
+        .setOutputType( this.outputType );
+
+      return clone;
+    }
+
+  }
+
   protected Log logger = LogFactory.getLog( this.getClass() );
   protected final String ENCODING = "UTF-8";
 
   private OutputStream out;
   private HttpServletResponse response;
 
-  private boolean download;
+  private Configuration configuration;
+  public Configuration getConfiguration() { return this.configuration; }
+
 
   protected OutputStream getOut() { return this.out; }
 
-  protected KettleOutput( HttpServletResponse response, boolean download ) {
+  protected KettleOutput( HttpServletResponse response, Configuration configuration ) {
     this.response = response;
-    this.download = download;
+    this.configuration = configuration;
 
     try {
       this.out = response.getOutputStream();
@@ -42,9 +106,6 @@ public abstract class KettleOutput implements IKettleOutput {
       this.logger.error( "Something went wrong on the KettleOutput class initialization.", ex );
     }
   }
-
-  // TODO: rename this getter... this says if a result is to be returned as an attachment / download file
-  protected boolean getDownload() { return this.download; }
 
   protected HttpServletResponse getResponse() { return this.response; }
 

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/ResultOnlyKettleOutput.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/ResultOnlyKettleOutput.java
@@ -15,17 +15,20 @@ package pt.webdetails.cpk.elements.impl.kettleoutputs;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.ObjectMapper;
+import pt.webdetails.cpf.utils.MimeTypes;
 import pt.webdetails.cpk.elements.impl.KettleResult;
+import pt.webdetails.cpk.utils.CpkUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class ResultOnlyKettleOutput extends KettleOutput {
 
-  public ResultOnlyKettleOutput( HttpServletResponse response, boolean download ) {
-    super( response, download );
-  }
+  public ResultOnlyKettleOutput( HttpServletResponse response, Configuration configuration ) {
+    super( response, configuration );
 
+    this.getConfiguration().setMimeType( MimeTypes.JSON );
+  }
 
   public static final class ResultStruct {
     boolean result;
@@ -68,6 +71,7 @@ public class ResultOnlyKettleOutput extends KettleOutput {
     ResultStruct resultStruct = new ResultStruct( result );
 
     try {
+      CpkUtils.setResponseHeaders( this.getResponse(), this.getConfiguration().getMimeType() );
       ObjectMapper mapper = new ObjectMapper();
       mapper.writeValue( this.getOut(), resultStruct );
     } catch ( IOException ex ) {

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/SingleCellKettleOutput.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/kettleoutputs/SingleCellKettleOutput.java
@@ -14,27 +14,18 @@
 package pt.webdetails.cpk.elements.impl.kettleoutputs;
 
 
-import org.apache.commons.io.IOUtils;
-import org.pentaho.di.core.vfs.KettleVFS;
 import pt.webdetails.cpk.elements.impl.KettleResult;
 import pt.webdetails.cpk.utils.CpkUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 
 public class SingleCellKettleOutput extends KettleOutput {
 
-  private String mimeType;
-  private String attachmentName;
-
-  public SingleCellKettleOutput( HttpServletResponse response, boolean download, String mimeType, String attachmentName ) {
-    super( response, download );
-
-    this.mimeType = mimeType;
-    this.attachmentName = attachmentName;
+  public SingleCellKettleOutput( HttpServletResponse response, Configuration configuration ) {
+    super( response, configuration );
   }
 
   @Override
@@ -46,12 +37,14 @@ public class SingleCellKettleOutput extends KettleOutput {
       if ( !result.getRows().isEmpty() ) {
         Object cell = result.getRows().get( 0 ).getData()[ 0 ];
         byte[] resultContent = cell.toString().getBytes( ENCODING );
-        if ( this.getDownload() ) {
+        String mimeType = this.getConfiguration().getMimeType();
+        if ( this.getConfiguration().getSendResultAsAttachment() ) {
           long attachmentSize = resultContent.length;
-          String attachmentName = this.attachmentName != null ? this.attachmentName : "singleCell";
-          CpkUtils.setResponseHeaders( this.getResponse(), this.mimeType, attachmentName, attachmentSize );
+          String defaultAttachmentName = this.getConfiguration().getAttachmentName();
+          String attachmentName = defaultAttachmentName != null ? defaultAttachmentName : "singleCell";
+          CpkUtils.setResponseHeaders( this.getResponse(), mimeType, attachmentName, attachmentSize );
         } else {
-          CpkUtils.setResponseHeaders( this.getResponse(), this.mimeType );
+          CpkUtils.setResponseHeaders( this.getResponse(), mimeType );
         }
         OutputStream out = this.getOut();
         out.write( resultContent );


### PR DESCRIPTION
- Default mime type for kettle element request responses can now be set in the corresponding ktr/kjb.
- Single cell results can now be returned as an attachment of a kettle element request response.
- Getting a single file / single cell result as an attachment (or not) as default can now be specified in the ktr/kjb.
- Default attachment name can now be specified on ktr/kjb.
