### PR TITLE
[SPARKL-37]

### DIFF
--- a/cpk-core/src/pt/webdetails/cpk/CpkEngine.java
+++ b/cpk-core/src/pt/webdetails/cpk/CpkEngine.java
@@ -119,7 +119,8 @@ public class CpkEngine {
     InputStream configFile = null;
     try {
       // get configuration from file
-      configFile = this.getEnvironment().getContentAccessFactory().getPluginSystemReader( "" ).getFileInputStream( DEFAULT_CACHE_SETTINGS_FILENAME );
+      configFile = this.getEnvironment().getContentAccessFactory().getPluginSystemReader( "" )
+        .getFileInputStream( DEFAULT_CACHE_SETTINGS_FILENAME );
       Configuration cacheManagerConfiguration = ConfigurationFactory.parseConfiguration( configFile );
       Collection<CacheConfiguration> cacheConfigurations = cacheManagerConfiguration.getCacheConfigurations().values();
       // get one cache configuration, ignore if more are present
@@ -128,13 +129,14 @@ public class CpkEngine {
       if ( cacheConfiguration.getName() == null || cacheConfiguration.getName().isEmpty() ) {
         cacheConfiguration.setName( this.getDefaultCacheName() );
       }
-      logger.debug( this.getEnvironment().getPluginName() + " is using cache configuration from file " + DEFAULT_CACHE_SETTINGS_FILENAME );
+      logger.debug( this.getEnvironment().getPluginName() + " is using cache configuration from file "
+        + DEFAULT_CACHE_SETTINGS_FILENAME );
     }
     catch ( Exception ioe ) {
       // unable to load cache configuration file. Using hardcoded default configuration.
-      logger.error( "Error reading cache configuration file " + DEFAULT_CACHE_SETTINGS_FILENAME );
+      logger.info( "No Eh cache configuration file found " + DEFAULT_CACHE_SETTINGS_FILENAME + "." );
       cacheConfiguration = this.getDefaultCacheConfiguration();
-      logger.debug( this.getEnvironment().getPluginName() + " is using default hardcoded cache configuration." );
+      logger.info( this.getEnvironment().getPluginName() + " is using default hardcoded cache configuration." );
     }
     finally {
       IOUtils.closeQuietly( configFile );

--- a/cpk-core/src/pt/webdetails/cpk/cache/EHCache.java
+++ b/cpk-core/src/pt/webdetails/cpk/cache/EHCache.java
@@ -58,6 +58,9 @@ public class EHCache<K extends Serializable, V extends Serializable> implements 
   public void put( K key, V value, int timeToLiveSeconds ) {
     final Element storeElement = new Element( key, value );
     storeElement.setTimeToLive( timeToLiveSeconds );
+    if ( timeToLiveSeconds == 0 ) {
+      storeElement.setTimeToIdle( 0 );
+    }
     this.cache.put( storeElement );
 
     // Print cache status size

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/KettleResultKey.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/KettleResultKey.java
@@ -15,7 +15,7 @@ package pt.webdetails.cpk.elements.impl;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class KettleResultKey implements Serializable {
@@ -38,14 +38,16 @@ public final class KettleResultKey implements Serializable {
   public Map<String, String> getParameters() { return Collections.unmodifiableMap( this.parameters ); }
 
 
-  // Constructors
+  // region Constructors
 
   public KettleResultKey( String pluginId, String elementId, String outputStepName, Map<String, String> parameters ) {
     this.pluginId = pluginId;
     this.elementId = elementId;
     this.outputStepName = outputStepName;
-    this.parameters = new Hashtable<String, String>( parameters );
+    this.parameters = new HashMap<String, String>( parameters );
   }
+
+  // endregion
 
   @Override
   public boolean equals( final Object other ) {

--- a/cpk-core/src/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java
+++ b/cpk-core/src/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java
@@ -71,8 +71,6 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
     return dataSource;
   }
 
-
-  // TODO: this method should replace processRequest eventually
   @Override
   protected KettleResult processRequest( Map<String, String> kettleParameters, String outputStepName ) {
     logger.info( "Starting transformation '" + this.getName() + "' (" + this.meta.getName() + ")" );
@@ -86,13 +84,10 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
       this.meta.setResultRows( new ArrayList<RowMetaAndData>() );
       this.meta.setResultFiles( new ArrayList<ResultFile>() );
 
-      // update parameters
-      KettleElementHelper.updateParameters( this.meta );
-
-      // add request parameters
-      Collection<String> addedParameters = Collections.emptyList();
+      // add parameters
+      Collection<String> setParameters = Collections.emptyList();
       if ( kettleParameters != null ) {
-        addedParameters = KettleElementHelper.addKettleParameters( this.meta, kettleParameters );
+        setParameters = KettleElementHelper.setKettleParameterValues( this.meta, kettleParameters );
       }
 
       // create a new transformation
@@ -120,13 +115,12 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
 
       // assemble kettle result
       Result transformationResult = transformation.getResult();
-      rows.addAll( transformationResult.getRows() );
       transformationResult.setRows( rows );
       result = new KettleResult( transformationResult );
       result.setKettleType( KettleResult.KettleType.TRANSFORMATION );
 
       // clear request parameters
-      KettleElementHelper.clearParameters( meta, addedParameters );
+      KettleElementHelper.clearParameters( meta, setParameters );
 
     } catch ( KettleException e ) {
       logger.debug( "KETTLE EXCEPTION: " + e, e );
@@ -172,26 +166,5 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
       }
     }
     return validOutputStepNames;
-  }
-
-
-  public static void execute( String kettleTransformationPath ) {
-    try {
-      // load transformation meta info
-      TransMeta transMeta = new TransMeta( kettleTransformationPath );
-      // add base parameters to ensure they exist
-      KettleElementHelper.addBaseParameters( transMeta );
-      // update parameters
-      KettleElementHelper.updateParameters( transMeta );
-      // create a new transformation
-      Trans transformation = new Trans( transMeta );
-      // prepare execution
-      transformation.prepareExecution( null );
-      // start transformation threads and wait until they finish
-      transformation.startThreads();
-      transformation.waitUntilFinished();
-    } catch ( KettleException e ) {
-      // do nothing?
-    }
   }
 }


### PR DESCRIPTION
- Corrected bug: When a user executes a kettle endpoint she may receive the cached result value of another user.
- Corrected bug: When a user specifies in the ktr/kjb cpk.cache.timeToLiveSeconds=0, no result is cached as opposed to set time to live to infinity.
- The value of  CPK parameters that are not declared in the ktr / kjb file are no longer injected. Only values of declared CPK parameters are injected.
- Refactored KettleElementHelper class and auxiliary functions/structures related to kettle parameter handling in general.
