### PR TITLE
[CDF-962] - CpkApi methods in Cpk should not be void - warnings in console

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
+++ b/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -39,6 +39,9 @@ public class CpkCoreService {
 
   private static final Log logger = LogFactory.getLog( CpkCoreService.class );
   private static final String ENCODING = "UTF-8";
+  private static final String HTTP_RESPONSE_KEY = "httpresponse";
+  private static final String PATH_KEY = "path";
+  private static final String TEXT_PLAIN_CONTENT = "text/plain";
 
   private CpkEngine engine;
 
@@ -59,7 +62,7 @@ public class CpkCoreService {
 
   public void createContent( Map<String, Map<String, Object>> bloatedMap ) throws Exception {
     final ICpkEnvironment environment = this.getEngine().getEnvironment();
-    final HttpServletResponse response = (HttpServletResponse) bloatedMap.get( "path" ).get( "httpresponse" );
+    final HttpServletResponse response = (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY );
 
     final String path = getPath( bloatedMap );
 
@@ -93,7 +96,7 @@ public class CpkCoreService {
   }
 
   private String getPath( Map<String, Map<String, Object>> bloatedMap ) {
-    String path = (String) bloatedMap.get( "path" ).get( "path" );
+    String path = (String) bloatedMap.get( PATH_KEY ).get( PATH_KEY );
 
     if ( path == null ) {
       return "";
@@ -146,6 +149,10 @@ public class CpkCoreService {
     refresh( out, bloatedMap );
   }
 
+  public String reload( Map<String, Map<String, Object>> bloatedMap ) {
+    return refresh( bloatedMap );
+  }
+
   public void refresh( OutputStream out, Map<String, Map<String, Object>> bloatedMap ) {
     IAccessControl accessControl = this.getEngine().getEnvironment().getAccessControl();
 
@@ -154,8 +161,21 @@ public class CpkCoreService {
       this.getEngine().reload();
       status( out, bloatedMap );
     } else {
-      accessControl.throwAccessDenied( (HttpServletResponse) bloatedMap.get( "path" ).get( "httpresponse" ) );
+      accessControl.throwAccessDenied( (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY ) );
     }
+  }
+
+  public String refresh( Map<String, Map<String, Object>> bloatedMap ) {
+    IAccessControl accessControl = this.getEngine().getEnvironment().getAccessControl();
+
+    if ( accessControl.isAdmin() ) {
+      this.getEngine().reload();
+      return status( bloatedMap );
+    } else {
+      accessControl.throwAccessDenied( (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY ) );
+    }
+
+    return null;
   }
 
   public void clearKettleResultsCache() {
@@ -167,17 +187,28 @@ public class CpkCoreService {
   }
 
   public void status( OutputStream out, Map<String, Map<String, Object>> bloatedMap ) {
-    HttpServletResponse response = (HttpServletResponse) bloatedMap.get( "path" ).get( "httpresponse" );
+    HttpServletResponse response = (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY );
 
     logger.debug( "## status ##" );
     logger.info( "Showing status for CPK plugin " + this.getEngine().getEnvironment().getPluginName() );
+    // Only set the headers if we have access to the response (via parameterProviders).
+    if ( response != null ) {
+      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
+    }
+
+    String status = this.getEngine().getStatus().getStatus();
+    writeMessage( out, status );
+  }
+
+  public String status( Map<String, Map<String, Object>> bloatedMap ) {
+    HttpServletResponse response = (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY );
 
     // Only set the headers if we have access to the response (via parameterProviders).
     if ( response != null ) {
-      CpkUtils.setResponseHeaders( response, "text/plain" );
+      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
     }
 
-    writeMessage( out, this.getEngine().getStatus().getStatus() );
+    return this.getEngine().getStatus().getStatus();
   }
 
   public void statusJson( OutputStream out, HttpServletResponse response ) {
@@ -185,10 +216,20 @@ public class CpkCoreService {
 
     // Only set the headers if we have access to the response (via parameterProviders).
     if ( response != null ) {
-      CpkUtils.setResponseHeaders( response, "text/plain" );
+      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
     }
 
-    writeMessage( out, this.getEngine().getStatus().getStatusJson() );
+    String json = this.getEngine().getStatus().getStatusJson();
+    writeMessage( out, json );
+  }
+
+  public String statusJson( HttpServletResponse response ) {
+    // Only set the headers if we have access to the response (via parameterProviders).
+    if ( response != null ) {
+      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
+    }
+
+    return this.getEngine().getStatus().getStatusJson();
   }
 
   public boolean hasElement( String elementId ) {
@@ -205,14 +246,26 @@ public class CpkCoreService {
     logger.debug( "## getElementsList ##" );
 
     ObjectMapper mapper = new ObjectMapper();
+    String json = null;
 
     try {
-      String json = mapper.writeValueAsString( this.getEngine().getElements() );
+      json = mapper.writeValueAsString( this.getEngine().getElements() );
 
       writeMessage( out, json );
     } catch ( IOException ex ) {
       logger.error( "Error getting json elements", ex );
     }
+  }
+
+  public String getElementsList() {
+    ObjectMapper mapper = new ObjectMapper();
+
+    try {
+      return mapper.writeValueAsString( this.getEngine().getElements() );
+    } catch ( IOException ex ) {
+      logger.error( "Error getting json elements", ex );
+    }
+    return null;
   }
 
   public IElement getDefaultElement() {

--- a/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
+++ b/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
@@ -154,15 +154,8 @@ public class CpkCoreService {
   }
 
   public void refresh( OutputStream out, Map<String, Map<String, Object>> bloatedMap ) {
-    IAccessControl accessControl = this.getEngine().getEnvironment().getAccessControl();
-
-    if ( accessControl.isAdmin() ) {
-      logger.info( "Refreshing CPK plugin " + this.getEngine().getEnvironment().getPluginName() );
-      this.getEngine().reload();
-      status( out, bloatedMap );
-    } else {
-      accessControl.throwAccessDenied( (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY ) );
-    }
+    String resultFromRefresh = refresh( bloatedMap );
+    writeMessage( out, resultFromRefresh );
   }
 
   public String refresh( Map<String, Map<String, Object>> bloatedMap ) {
@@ -187,16 +180,7 @@ public class CpkCoreService {
   }
 
   public void status( OutputStream out, Map<String, Map<String, Object>> bloatedMap ) {
-    HttpServletResponse response = (HttpServletResponse) bloatedMap.get( PATH_KEY ).get( HTTP_RESPONSE_KEY );
-
-    logger.debug( "## status ##" );
-    logger.info( "Showing status for CPK plugin " + this.getEngine().getEnvironment().getPluginName() );
-    // Only set the headers if we have access to the response (via parameterProviders).
-    if ( response != null ) {
-      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
-    }
-
-    String status = this.getEngine().getStatus().getStatus();
+    String status = status( bloatedMap );
     writeMessage( out, status );
   }
 
@@ -212,14 +196,7 @@ public class CpkCoreService {
   }
 
   public void statusJson( OutputStream out, HttpServletResponse response ) {
-    logger.info( "Showing status for CPK plugin " + this.getEngine().getEnvironment().getPluginName() );
-
-    // Only set the headers if we have access to the response (via parameterProviders).
-    if ( response != null ) {
-      CpkUtils.setResponseHeaders( response, TEXT_PLAIN_CONTENT );
-    }
-
-    String json = this.getEngine().getStatus().getStatusJson();
+    String json = statusJson( response );
     writeMessage( out, json );
   }
 
@@ -243,17 +220,9 @@ public class CpkCoreService {
   }
 
   public void getElementsList( OutputStream out, Map<String, Map<String, Object>> bloatedMap ) {
-    logger.debug( "## getElementsList ##" );
-
-    ObjectMapper mapper = new ObjectMapper();
-    String json = null;
-
-    try {
-      json = mapper.writeValueAsString( this.getEngine().getElements() );
-
-      writeMessage( out, json );
-    } catch ( IOException ex ) {
-      logger.error( "Error getting json elements", ex );
+    String elements = getElementsList();
+    if ( elements != null ) {
+      writeMessage( out, elements );
     }
   }
 

--- a/core/src/main/java/pt/webdetails/cpk/utils/CpkUtils.java
+++ b/core/src/main/java/pt/webdetails/cpk/utils/CpkUtils.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -18,9 +18,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 public class CpkUtils {
@@ -83,6 +86,10 @@ public class CpkUtils {
     }
   }
 
+  public static Response redirect( String url ) throws URISyntaxException {
+    return Response.temporaryRedirect( new URI( url ) ).build();
+  }
+
 
   public static Map<String, Object> getRequestParameters(
     Map<String, Map<String, Object>> bloatedMap ) {
@@ -111,7 +118,7 @@ public class CpkUtils {
 
   public static void send( HttpServletResponse response, InputStream fileInputStream, String mimeTypes,
                      String fileName, boolean sendAsAttachment, Integer contentLength ) {
-    if ( mimeTypes != null && !mimeTypes.isEmpty()) {
+    if ( mimeTypes != null && !mimeTypes.isEmpty() ) {
       response.setContentType( mimeTypes );
     }
 
@@ -130,6 +137,16 @@ public class CpkUtils {
     } catch ( Exception ex ) {
       logger.error( "Failed to copy file to outputstream: " + ex );
     }
+  }
+
+  public static Response.Status getEquivalentStatusFromHttpServletResponse( HttpServletResponse response ) {
+    if ( response != null ) {
+      Response.Status equivalentStatus = Response.Status.fromStatusCode( response.getStatus() );
+      if ( equivalentStatus != null ) {
+        return equivalentStatus;
+      }
+    }
+    return Response.Status.OK;
   }
 
 }

--- a/core/src/test/java/pt/webdetails/cpk/CpkCoreKettleElementTest.java
+++ b/core/src/test/java/pt/webdetails/cpk/CpkCoreKettleElementTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -19,7 +19,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
-import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.IRepositoryAccess;
 import pt.webdetails.cpf.repository.vfs.VfsRepositoryAccess;
 import pt.webdetails.cpf.utils.IPluginUtils;
@@ -28,7 +27,7 @@ import pt.webdetails.cpk.testUtils.HttpServletResponseForTesting;
 import pt.webdetails.cpk.testUtils.PluginUtilsForTesting;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.File;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,7 +40,7 @@ public class CpkCoreKettleElementTest {
   private static ICpkEnvironment environment;
 
   @BeforeClass
-  public static void setUp() throws IOException, InitializationException, KettleException {
+  public static void setUp() throws KettleException {
 
     IRepositoryAccess repAccess = new VfsRepositoryAccess( userDir + "/target/test-classes/cpkSol",
       userDir + "/target/test-classes/settings" );
@@ -67,9 +66,10 @@ public class CpkCoreKettleElementTest {
     // define the expected result
     HashMap<String, String> parameters = new HashMap<String, String>();
     parameters.put( "pluginId", "cpkSol" );
-    parameters.put( "solutionSystemDir", userDir + "/target/test-classes/" );
-    parameters.put( "pluginDir", userDir + "/target/test-classes/cpkSol/" );
-    parameters.put( "pluginSystemDir", userDir + "/target/test-classes/cpkSol/system/" );
+    parameters.put( "solutionSystemDir", getFolderPathOSDependent( userDir + "/target/test-classes/" ) );
+    parameters.put( "pluginDir", getFolderPathOSDependent( userDir + "/target/test-classes/cpkSol/" ) );
+    parameters.put( "pluginSystemDir", getFolderPathOSDependent( userDir
+      + "/target/test-classes/cpkSol/system/" ) );
     parameters.put( "webappDir", "" );
     parameters.put( "sessionUsername", "userName" );
     parameters.put( "sessionRoles", "{\"roles\":[\"administrator\",\"authenticated\"]}" );
@@ -84,6 +84,10 @@ public class CpkCoreKettleElementTest {
         Assert.assertEquals( paramValue, parameters.get( paramName ) );
       }
     }
+  }
+
+  private String getFolderPathOSDependent( String folderPath ) {
+    return new File( folderPath ).toURI().getPath();
   }
 
   private Map<String, Map<String, Object>> testParameters( OutputStream outResponse ) {

--- a/core/src/test/java/pt/webdetails/cpk/CpkCoreServiceTest.java
+++ b/core/src/test/java/pt/webdetails/cpk/CpkCoreServiceTest.java
@@ -196,9 +196,7 @@ public class CpkCoreServiceTest {
     String str = out.toString();
 
     JSONArray elementsListJson = new JSONArray( str );
-    boolean successful = checkIdLength( elementsListJson );
-
-    assertTrue( successful );
+    assertTrue( checkIdLength( elementsListJson ) );
     out.close();
   }
 
@@ -206,19 +204,18 @@ public class CpkCoreServiceTest {
   public void testGetElementsListStringResult() throws JSONException {
     String actualResult = cpkCore.getElementsList();
     JSONArray elementsListJson = new JSONArray( actualResult );
-    boolean successful = checkIdLength( elementsListJson );
-    assertTrue( successful );
+    assertTrue( checkIdLength( elementsListJson ) );
   }
 
   private boolean checkIdLength( JSONArray elementsListJson ) throws JSONException {
+    assertNotNull( elementsListJson );
+
     boolean successful = true;
-    if ( elementsListJson != null ) {
-      for ( int i = 0; i < elementsListJson.length(); i++ ) {
-        JSONObject obj = elementsListJson.getJSONObject( i );
-        String id = obj.getString( "id" );
-        if ( id.length() < 1 ) {
-          successful = false;
-        }
+    for ( int i = 0; i < elementsListJson.length(); i++ ) {
+      JSONObject obj = elementsListJson.getJSONObject( i );
+      String id = obj.getString( "id" );
+      if ( id.length() < 1 ) {
+        successful = false;
       }
     }
     return successful;

--- a/core/src/test/java/pt/webdetails/cpk/CpkCoreServiceTest.java
+++ b/core/src/test/java/pt/webdetails/cpk/CpkCoreServiceTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -59,9 +59,10 @@ import static org.mockito.Mockito.spy;
 public class CpkCoreServiceTest {
 
   private static CpkCoreService cpkCore;
-
   private static Map<String, Map<String, Object>> bloatedMap;
   private static OutputStream outResponse;
+
+  private static final String STATUS_RESULT = "cpkSol Status";
 
   @BeforeClass
   public static void setUp() throws KettleException {
@@ -190,24 +191,37 @@ public class CpkCoreServiceTest {
 
   @Test
   public void testGetElementsList() throws IOException, JSONException {
-    boolean successful = true;
-
     OutputStream out = new ByteArrayOutputStream();
     cpkCore.getElementsList( out, bloatedMap );
     String str = out.toString();
 
     JSONArray elementsListJson = new JSONArray( str );
-
-    for ( int i = 0; i < elementsListJson.length(); i++ ) {
-      JSONObject obj = elementsListJson.getJSONObject( i );
-      String id = obj.getString( "id" );
-      if ( id.length() < 1 ) {
-        successful = false;
-      }
-    }
+    boolean successful = checkIdLength( elementsListJson );
 
     assertTrue( successful );
     out.close();
+  }
+
+  @Test
+  public void testGetElementsListStringResult() throws JSONException {
+    String actualResult = cpkCore.getElementsList();
+    JSONArray elementsListJson = new JSONArray( actualResult );
+    boolean successful = checkIdLength( elementsListJson );
+    assertTrue( successful );
+  }
+
+  private boolean checkIdLength( JSONArray elementsListJson ) throws JSONException {
+    boolean successful = true;
+    if ( elementsListJson != null ) {
+      for ( int i = 0; i < elementsListJson.length(); i++ ) {
+        JSONObject obj = elementsListJson.getJSONObject( i );
+        String id = obj.getString( "id" );
+        if ( id.length() < 1 ) {
+          successful = false;
+        }
+      }
+    }
+    return successful;
   }
 
   @Test
@@ -220,8 +234,37 @@ public class CpkCoreServiceTest {
     String str = out.toString();
     out.close();
 
-    assertTrue( str.contains( "cpkSol Status" ) );
+    assertTrue( str.contains( STATUS_RESULT ) );
     assertFalse( str.contains( "null" ) );
+  }
+
+  @Test
+  public void testReloadRefreshStatusStringResult() throws IOException {
+    OutputStream out = new ByteArrayOutputStream();
+    refreshBloatedMapStream( out );
+
+    String actualResult = cpkCore.reload( bloatedMap );
+
+    assertTrue( actualResult.contains( STATUS_RESULT ) );
+    assertFalse( actualResult.contains( "null" ) );
+  }
+
+  @Test
+  public void testStatusJson() {
+    String actualResult = null;
+    try {
+      actualResult = cpkCore.statusJson( null );
+      JSONObject jsonObj = new JSONObject( actualResult );
+      assertTrue( jsonObj.has( "pluginName" ) );
+      assertEquals( "cpkSol", jsonObj.get( "pluginName" ) );
+      assertTrue( jsonObj.has( "elements" ) );
+      assertTrue( jsonObj.get( "elements" ) instanceof JSONObject );
+      assertTrue( jsonObj.has( "elementsCount" ) );
+      assertTrue( jsonObj.has( "defaultElement" ) );
+    } catch ( JSONException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( actualResult );
   }
 
   @Test

--- a/core/src/test/java/pt/webdetails/cpk/testUtils/HttpServletResponseForTesting.java
+++ b/core/src/test/java/pt/webdetails/cpk/testUtils/HttpServletResponseForTesting.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -21,10 +21,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Locale;
 
 public class HttpServletResponseForTesting implements HttpServletResponse {
   private OutputStream outputStream;
+  private int status;
 
   public HttpServletResponseForTesting( OutputStream outputStream ) {
     this.outputStream = outputStream;
@@ -53,6 +55,22 @@ public class HttpServletResponseForTesting implements HttpServletResponse {
 
   @Override public String encodeRedirectUrl( String s ) {
     return null;  //To change body of implemented methods use File | Settings | File Templates.
+  }
+
+  @Override public int getStatus() {
+    return this.status;
+  }
+
+  @Override public Collection<String> getHeaderNames() {
+    return null;
+  }
+
+  @Override public Collection<String> getHeaders( String name ) {
+    return null;
+  }
+
+  @Override public String getHeader( String name ) {
+    return null;
   }
 
   @Override public void sendError( int i, String s ) throws IOException {
@@ -92,7 +110,7 @@ public class HttpServletResponseForTesting implements HttpServletResponse {
   }
 
   @Override public void setStatus( int i ) {
-    //To change body of implemented methods use File | Settings | File Templates.
+    this.status = i;
   }
 
   @Override public void setStatus( int i, String s ) {

--- a/core/src/test/java/pt/webdetails/cpk/utils/CpkUtilsTest.java
+++ b/core/src/test/java/pt/webdetails/cpk/utils/CpkUtilsTest.java
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpk.utils;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import pt.webdetails.cpk.testUtils.HttpServletResponseForTesting;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+public class CpkUtilsTest {
+
+  @Test
+  public void testStatusCodeEquivalents() {
+    OutputStream out = new ByteArrayOutputStream();
+    HttpServletResponse httpResponse = new HttpServletResponseForTesting( out );
+
+    httpResponse.setStatus( HttpServletResponse.SC_OK );
+    Response.Status respStatus = CpkUtils.getEquivalentStatusFromHttpServletResponse( httpResponse );
+    assertEquals( Response.Status.OK, respStatus );
+
+    httpResponse.setStatus( HttpServletResponse.SC_INTERNAL_SERVER_ERROR );
+    respStatus = CpkUtils.getEquivalentStatusFromHttpServletResponse( httpResponse );
+    assertEquals( Response.Status.INTERNAL_SERVER_ERROR, respStatus );
+
+    httpResponse.setStatus( HttpServletResponse.SC_NO_CONTENT );
+    respStatus = CpkUtils.getEquivalentStatusFromHttpServletResponse( httpResponse );
+    assertEquals( Response.Status.NO_CONTENT, respStatus );
+
+    httpResponse.setStatus( HttpServletResponse.SC_FORBIDDEN );
+    respStatus = CpkUtils.getEquivalentStatusFromHttpServletResponse( httpResponse );
+    assertEquals( Response.Status.FORBIDDEN, respStatus );
+  }
+}

--- a/pentaho5/pom.xml
+++ b/pentaho5/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -103,7 +103,6 @@
       <artifactId>json</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -122,6 +121,22 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${jsonassert.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pentaho5/src/test/java/pt/webdetails/cpk/CpkApiTest.java
+++ b/pentaho5/src/test/java/pt/webdetails/cpk/CpkApiTest.java
@@ -1,0 +1,403 @@
+/*!
+ * Copyright 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpk;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.mock.web.DelegatingServletOutputStream;
+
+import pt.webdetails.cpf.plugins.Plugin;
+import pt.webdetails.cpk.datasources.DataSource;
+import pt.webdetails.cpk.datasources.DataSourceDefinition;
+import pt.webdetails.cpk.datasources.DataSourceMetadata;
+import pt.webdetails.cpk.elements.IDataSourceProvider;
+import pt.webdetails.cpk.elements.IElement;
+import pt.webdetails.cpk.elements.impl.DashboardElement;
+import pt.webdetails.cpk.testUtils.CpkApiForTesting;
+import pt.webdetails.cpk.testUtils.HttpHeadersForTesting;
+import pt.webdetails.cpk.testUtils.HttpServletRequestForTesting;
+import pt.webdetails.cpk.testUtils.HttpServletResponseForTesting;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.withSettings;
+import static pt.webdetails.cpk.CpkApi.CPK_ENDPOINT_KEY;
+import static pt.webdetails.cpk.CpkApi.CPK_ENDPOINT_SEPARATOR;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+public class CpkApiTest {
+
+  private CpkApi cpkApi = null;
+  private HttpServletRequest request = null;
+  private HttpServletResponse response = null;
+  private HttpHeaders headers = null;
+
+  private static String userDir = System.getProperty( "user.dir" );
+  private static final String TEST_RESULT = "Test Successful";
+  private static final String TEST_RESULT_JSON = "{\"result\": \"Test Successful\"}";
+  private static final String DEFAULT_ELEMENT_ID = "DefaultElementId";
+  private static final String DEFAULT_ELEMENT_PLUGIN_ID = "DefaultElementPluginId";
+  private static final String DATA_SOURCE_NAME = "DataSourceName";
+  private static final String DATA_SOURCE_DATA_TYPE = "DataSourceDataType";
+  private static final String DATA_SOURCE_GROUP_ID = "DataSourceGroupId";
+  private static final String DATA_SOURCE_GROUP_DESCRIPTION = "DataSourceGroupDescription";
+
+  @Before
+  public void setUp() {
+    cpkApi = new CpkApiForTesting();
+    request = new HttpServletRequestForTesting();
+    OutputStream out = new ByteArrayOutputStream();
+    response = new HttpServletResponseForTesting( out );
+    headers = new HttpHeadersForTesting();
+  }
+
+  @Test
+  public void testGenericEndpoint() {
+    Response responseResult = null;
+    try {
+      doAnswer( new Answer() {
+        public Object answer( InvocationOnMock invocation ) {
+          Object[] args = invocation.getArguments();
+          HttpServletResponseForTesting response = getResponse( (Map) args[0] );
+          try {
+            if ( response != null && response.getOutputStream() != null ) {
+              response.getOutputStream().write( TEST_RESULT.getBytes() );
+              response.setStatus( HttpServletResponse.SC_OK );
+            }
+          } catch ( IOException ex ) {
+            ex.printStackTrace();
+          }
+          return null;
+        } } )
+      .when( cpkApi.coreService ).createContent( anyMap() );
+
+      responseResult = cpkApi.genericEndpointGet( "/", request, response, headers );
+      assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+      assertEquals( HttpServletResponse.SC_OK, response.getStatus() );
+      assertEquals( TEST_RESULT, getStringValue( response.getOutputStream() ) );
+    } catch ( Exception ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testPing() {
+    String actualResult = cpkApi.ping();
+    assertEquals( cpkApi.PING_RESPONSE + cpkApi.getPluginName(), actualResult );
+  }
+
+  @Test
+  public void testDefaultElement() {
+    IElement defaultElement = Mockito.mock( IElement.class );
+    when( defaultElement.getPluginId() ).thenReturn( DEFAULT_ELEMENT_PLUGIN_ID );
+    when( defaultElement.getId() ).thenReturn( DEFAULT_ELEMENT_ID );
+
+    when( cpkApi.coreService.getDefaultElement() ).thenReturn( defaultElement );
+
+    String expectedUrl = DEFAULT_ELEMENT_PLUGIN_ID + cpkApi.API_ROOT + DEFAULT_ELEMENT_ID;
+
+    Response responseResult = null;
+    try {
+      responseResult = cpkApi.defaultElement();
+      assertEquals( Response.Status.TEMPORARY_REDIRECT.getStatusCode(), responseResult.getStatus() );
+      assertEquals( expectedUrl, responseResult.getMetadata().get( "Location" ).get( 0 ).toString() );
+    } catch ( IOException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testDefaultElementNotDefined() {
+    when( cpkApi.coreService.getDefaultElement() ).thenReturn( null );
+    Response responseResult = null;
+    try {
+      responseResult = cpkApi.defaultElement();
+      assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+      assertEquals( cpkApi.DEFAULT_NO_DASHBOARD_MESSAGE, new String( (byte[]) responseResult.getEntity() ) );
+    } catch ( IOException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testReload() {
+    when( cpkApi.coreService.reload( anyMap() ) ).thenReturn( TEST_RESULT );
+    Response responseResult = cpkApi.reload( request, response, headers );
+    assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+    assertEquals( TEST_RESULT, responseResult.getEntity() );
+  }
+
+  @Test
+  public void testRefresh() {
+    when( cpkApi.coreService.refresh( anyMap() ) ).thenReturn( TEST_RESULT );
+    Response responseResult = cpkApi.refreshGet( request, response, headers );
+    assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+    assertEquals( TEST_RESULT, responseResult.getEntity() );
+  }
+
+  @Test
+  public void testVersion() {
+    List<Plugin> plugins = new ArrayList<>();
+    Plugin pluginMock = Mockito.mock( Plugin.class );
+    when( pluginMock.getVersion() ).thenReturn( TEST_RESULT );
+    plugins.add( pluginMock );
+
+    doNothing().when( cpkApi.pluginsAnalyzer ).refresh();
+    when( cpkApi.pluginsAnalyzer.getPlugins( anyObject() ) ).thenReturn( plugins );
+
+    Response responseResult = cpkApi.version( cpkApi.cpkEnv.getPluginName() );
+    assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+    assertEquals( TEST_RESULT, responseResult.getEntity() );
+  }
+
+  @Test
+  public void testStatus() {
+    when( cpkApi.coreService.status( anyMap() ) ).thenReturn( TEST_RESULT );
+    commonTestStatus( TEST_RESULT );
+  }
+
+  @Test
+  public void testStatusJson() {
+    request.setAttribute( "json", "" );
+    when( cpkApi.coreService.statusJson( response ) ).thenReturn( TEST_RESULT_JSON );
+    commonTestStatus( TEST_RESULT_JSON );
+  }
+
+  @Test
+  public void testSitemapJson() {
+    IElement elementMock = Mockito.mock( DashboardElement.class );
+    when( elementMock.getLocation() ).thenReturn( userDir + "/target/test-classes/repository/system/cpkSol/dashboards/fileList.wcdf" );
+    when( elementMock.getId() ).thenReturn( "fileList" );
+
+    Map<String, IElement> elementsMap = new HashMap<>();
+    elementsMap.put( "filelist", elementMock );
+
+    CpkEngine engineMock = Mockito.mock( CpkEngine.class );
+    when( engineMock.getElementsMap() ).thenReturn( elementsMap );
+
+    when( cpkApi.coreService.getEngine() ).thenReturn( engineMock );
+
+    JSONArray expectedResult = getExpectedSiteMapJsonString();
+
+    Response responseResult = null;
+    try {
+      responseResult = cpkApi.getSitemapJson();
+      assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+      JSONAssert.assertEquals( expectedResult, new JSONArray( (String) responseResult.getEntity() ),
+        JSONCompareMode.LENIENT );
+    } catch ( IOException | JSONException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testElementsList() {
+    when( cpkApi.coreService.getElementsList() ).thenReturn( TEST_RESULT );
+    Response responseResult = cpkApi.elementsList();
+    assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+    assertEquals( TEST_RESULT, responseResult.getEntity() );
+  }
+
+  @Test
+  public void testListDataAccessTypesNoneExistent() {
+    List<IElement> endpoints = new ArrayList<>();
+    when( cpkApi.coreService.getElements() ).thenReturn( endpoints );
+
+    String expectedResult = "{}";
+
+    Response responseResult = null;
+    try {
+      responseResult = cpkApi.listDataAccessTypes();
+      assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+      assertEquals( expectedResult, responseResult.getEntity() );
+    } catch ( IOException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testListDataAccessTypes() {
+    DataSourceMetadata dsMetadata = new DataSourceMetadata();
+    dsMetadata.setDataType( DATA_SOURCE_DATA_TYPE );
+    dsMetadata.setGroup( DATA_SOURCE_GROUP_ID );
+    dsMetadata.setGroupDescription( DATA_SOURCE_GROUP_DESCRIPTION );
+    dsMetadata.setName( DATA_SOURCE_NAME );
+    dsMetadata.setPluginId( cpkApi.cpkEnv.getPluginName() );
+
+    DataSourceDefinition dsDefinition = new DataSourceDefinition();
+
+    DataSource dataSource = new DataSource();
+    dataSource.setMetadata( dsMetadata );
+    dataSource.setDefinition( dsDefinition );
+
+    IElement elementDataSourceMock = Mockito.mock( IElement.class,
+      withSettings().extraInterfaces( IDataSourceProvider.class ) );
+    when( elementDataSourceMock.getName() ).thenReturn( DATA_SOURCE_NAME );
+    when( ( (IDataSourceProvider) elementDataSourceMock ).getDataSource() ).thenReturn( dataSource );
+
+    List<IElement> endpoints = new ArrayList<>();
+    endpoints.add( elementDataSourceMock );
+
+    when( cpkApi.coreService.getElements() ).thenReturn( endpoints );
+
+    Response responseResult = null;
+    try {
+      responseResult = cpkApi.listDataAccessTypes();
+      assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+
+      JSONObject jsonObjectResult = new JSONObject( (String) responseResult.getEntity() );
+      String dataAccessName = String.format( "%s%s%s%s%s", cpkApi.cpkEnv.getPluginName(),
+        CPK_ENDPOINT_SEPARATOR, DATA_SOURCE_NAME, CPK_ENDPOINT_SEPARATOR, CPK_ENDPOINT_KEY );
+      JSONObject jsonObjectExpected = getExpectedDataAccessTypes( dataAccessName, dataSource );
+
+      JSONAssert.assertEquals( jsonObjectExpected, jsonObjectResult, JSONCompareMode.LENIENT );
+    } catch ( IOException | JSONException ex ) {
+      ex.printStackTrace();
+    }
+    assertNotNull( responseResult );
+  }
+
+  @Test
+  public void testReloadPluginsGet() {
+    Response responseResult = cpkApi.reloadPluginsGet();
+    assertEquals( Response.Status.NO_CONTENT.getStatusCode(), responseResult.getStatus() );
+  }
+
+  @Test
+  public void testClearCache() {
+    doNothing().when( cpkApi.coreService ).clearKettleResultsCache();
+    Response responseResult = cpkApi.clearKettleResultsCache();
+    assertEquals( Response.Status.NO_CONTENT.getStatusCode(), responseResult.getStatus() );
+  }
+
+  @After
+  public void tearDown() {
+    cpkApi = null;
+    request = null;
+    response = null;
+    headers = null;
+  }
+
+  private HttpServletResponseForTesting getResponse( Map map ) {
+    if ( map != null ) {
+      Map pathMap = (HashMap) map.get( "path" );
+      if ( pathMap != null ) {
+        return (HttpServletResponseForTesting) pathMap.get( "httpresponse" );
+      }
+    }
+    return null;
+  }
+
+  private String getStringValue( Object outputStream ) {
+    if ( outputStream != null ) {
+      if ( outputStream instanceof DelegatingServletOutputStream ) {
+        DelegatingServletOutputStream delegatingServletOutputStream = (DelegatingServletOutputStream) outputStream;
+        if ( delegatingServletOutputStream.getTargetStream() != null ) {
+          return delegatingServletOutputStream.getTargetStream().toString();
+        }
+      }
+    }
+    return null;
+  }
+
+  private void commonTestStatus( String expectedStringResult ) {
+    Response responseResult = cpkApi.status( request, response, headers );
+    assertEquals( Response.Status.OK.getStatusCode(), responseResult.getStatus() );
+    assertEquals( expectedStringResult, responseResult.getEntity() );
+    assertNotNull( responseResult );
+  }
+
+  private JSONArray getExpectedSiteMapJsonString() {
+    String jsonStr = "[{\"name\":\"dashboardsAnotherSublink\","
+      + "\"id\":\"\","
+      + "\"sublinks\":["
+        + "{\"name\":\"folder\","
+        + "\"id\":\"\","
+        + "\"sublinks\":[{\"name\":\"anotherFolder\",\"id\":\"\",\"sublinks\":[],\"link\":\"\"}],"
+        + "\"link\":\"\"}],"
+      + "\"link\":\"\"},"
+      + "{\"name\":\"dashboardsSublink\","
+      + "\"id\":\"\","
+      + "\"sublinks\":["
+        + "{\"name\":\"folder\","
+        + "\"id\":\"\","
+        + "\"sublinks\":[{\"name\":\"anotherFolder\",\"id\":\"\",\"sublinks\":[],\"link\":\"\"}],"
+        + "\"link\":\"\"}],"
+      + "\"link\":\"\"},"
+      + "{\"name\":\"File List Dashboard\","
+      + "\"id\":\"fileList.wcdf\","
+      + "\"sublinks\":[],"
+      + "\"link\":\"/pentaho/plugin/cpkSol/api/filelist\"}]";
+    try {
+      return new JSONArray( jsonStr );
+    } catch ( JSONException ex ) {
+      ex.printStackTrace();
+    }
+    return null;
+  }
+
+  private JSONObject getExpectedDataAccessTypes( String dataAccessName, DataSource dataSource ) {
+    JSONObject jsonObject = new JSONObject();
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JSONObject joDefinitions = new JSONObject( mapper.writeValueAsString( dataSource.getDefinition() ) );
+      JSONObject joMetadata = new JSONObject( mapper.writeValueAsString( dataSource.getMetadata() ) );
+
+      JSONObject joDataSource = new JSONObject();
+      joDataSource.put( "definition", joDefinitions );
+      joDataSource.put( "metadata", joMetadata );
+
+      jsonObject.put( dataAccessName, joDataSource );
+
+    } catch ( IOException | JSONException ex ) {
+      ex.printStackTrace();
+    }
+    return jsonObject;
+  }
+}

--- a/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/CpkApiForTesting.java
+++ b/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/CpkApiForTesting.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,20 +13,21 @@
 
 package pt.webdetails.cpk.testUtils;
 
+import org.mockito.Mockito;
+import pt.webdetails.cpf.plugins.PluginsAnalyzer;
 import pt.webdetails.cpk.CpkApi;
 import pt.webdetails.cpk.CpkCoreService;
 
-public class CpkApiForTesting extends CpkApi {
 
-  private static final String[] reserverdWords = { "default", "refresh", "status", "reload", "getElementsList",
-    "getSitemapJson", "version", "getPluginMetadata" };
+public class CpkApiForTesting extends CpkApi {
 
   public CpkApiForTesting() {
   }
 
   @Override
   protected void init() {
-    this.cpkEnv = new CpkPentahoEnvironmentForTesting( new PluginUtilsForTesting(), reserverdWords );
-    this.coreService = new CpkCoreService( cpkEnv );
+    this.cpkEnv = new CpkPentahoEnvironmentForTesting( new PluginUtilsForTesting(), reservedWords );
+    this.coreService = Mockito.mock( CpkCoreService.class );
+    this.pluginsAnalyzer = Mockito.mock( PluginsAnalyzer.class );
   }
 }

--- a/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpHeadersForTesting.java
+++ b/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpHeadersForTesting.java
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpk.testUtils;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class HttpHeadersForTesting implements HttpHeaders {
+  @Override
+  public List<String> getRequestHeader( String name ) {
+    return null;
+  }
+
+  @Override
+  public MultivaluedMap<String, String> getRequestHeaders() {
+    return null;
+  }
+
+  @Override
+  public List<MediaType> getAcceptableMediaTypes() {
+    return null;
+  }
+
+  @Override
+  public List<Locale> getAcceptableLanguages() {
+    return null;
+  }
+
+  @Override
+  public MediaType getMediaType() {
+    return null;
+  }
+
+  @Override
+  public Locale getLanguage() {
+    return null;
+  }
+
+  @Override
+  public Map<String, Cookie> getCookies() {
+    return null;
+  }
+}

--- a/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpServletRequestForTesting.java
+++ b/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpServletRequestForTesting.java
@@ -1,0 +1,387 @@
+/*!
+ * Copyright 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpk.testUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.DispatcherType;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Enumeration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+
+public class HttpServletRequestForTesting implements HttpServletRequest {
+  private Map params = null;
+
+  @Override
+  public String getAuthType() {
+    return null;
+  }
+
+  @Override
+  public Cookie[] getCookies() {
+    return new Cookie[0];
+  }
+
+  @Override
+  public long getDateHeader( String name ) {
+    return 0;
+  }
+
+  @Override
+  public String getHeader( String name ) {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getHeaders( String name ) {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getHeaderNames() {
+    return null;
+  }
+
+  @Override
+  public int getIntHeader( String name ) {
+    return 0;
+  }
+
+  @Override
+  public String getMethod() {
+    return null;
+  }
+
+  @Override
+  public String getPathInfo() {
+    return null;
+  }
+
+  @Override
+  public String getPathTranslated() {
+    return null;
+  }
+
+  @Override
+  public String getContextPath() {
+    return null;
+  }
+
+  @Override
+  public String getQueryString() {
+    return null;
+  }
+
+  @Override
+  public String getRemoteUser() {
+    return null;
+  }
+
+  @Override
+  public boolean isUserInRole( String role ) {
+    return false;
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return null;
+  }
+
+  @Override
+  public String getRequestedSessionId() {
+    return null;
+  }
+
+  @Override
+  public String getRequestURI() {
+    return null;
+  }
+
+  @Override
+  public StringBuffer getRequestURL() {
+    return null;
+  }
+
+  @Override
+  public String getServletPath() {
+    return null;
+  }
+
+  @Override
+  public HttpSession getSession( boolean create ) {
+    return null;
+  }
+
+  @Override
+  public HttpSession getSession() {
+    return null;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdValid() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromCookie() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromURL() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromUrl() {
+    return false;
+  }
+
+  @Override
+  public boolean authenticate( HttpServletResponse response ) throws IOException, ServletException {
+    return false;
+  }
+
+  @Override
+  public void login( String username, String password ) throws ServletException {
+
+  }
+
+  @Override
+  public void logout() throws ServletException {
+
+  }
+
+  @Override
+  public Collection<Part> getParts() throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public Part getPart( String name ) throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public Object getAttribute( String name ) {
+    if ( this.params != null && this.params.containsKey( name ) ) {
+      return this.params.get( name );
+    }
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getAttributeNames() {
+    if ( this.params != null ) {
+      return Collections.enumeration( this.params.keySet() );
+    }
+    return null;
+  }
+
+  @Override
+  public String getCharacterEncoding() {
+    return null;
+  }
+
+  @Override
+  public void setCharacterEncoding( String env ) throws UnsupportedEncodingException {
+
+  }
+
+  @Override
+  public int getContentLength() {
+    return 0;
+  }
+
+  @Override
+  public String getContentType() {
+    return null;
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getParameter( String name ) {
+    Object parameter = getAttribute( name );
+    if ( parameter != null ) {
+      return parameter.toString();
+    }
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getParameterNames() {
+    return getAttributeNames();
+  }
+
+  @Override
+  public String[] getParameterValues( String name ) {
+    return new String[0];
+  }
+
+  @Override
+  public Map<String, String[]> getParameterMap() {
+    return null;
+  }
+
+  @Override
+  public String getProtocol() {
+    return null;
+  }
+
+  @Override
+  public String getScheme() {
+    return null;
+  }
+
+  @Override
+  public String getServerName() {
+    return null;
+  }
+
+  @Override
+  public int getServerPort() {
+    return 0;
+  }
+
+  @Override
+  public BufferedReader getReader() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getRemoteAddr() {
+    return null;
+  }
+
+  @Override
+  public String getRemoteHost() {
+    return null;
+  }
+
+  @Override
+  public void setAttribute( String name, Object o ) {
+    if ( this.params == null ) {
+      this.params = new HashMap();
+    }
+    this.params.put( name, o );
+  }
+
+  @Override
+  public void removeAttribute( String name ) {
+    if ( this.params != null && this.params.containsKey( name ) ) {
+      this.params.remove( name );
+    }
+  }
+
+  @Override
+  public Locale getLocale() {
+    return null;
+  }
+
+  @Override
+  public Enumeration<Locale> getLocales() {
+    return null;
+  }
+
+  @Override
+  public boolean isSecure() {
+    return false;
+  }
+
+  @Override
+  public RequestDispatcher getRequestDispatcher( String path ) {
+    return null;
+  }
+
+  @Override
+  public String getRealPath( String path ) {
+    return null;
+  }
+
+  @Override
+  public int getRemotePort() {
+    return 0;
+  }
+
+  @Override
+  public String getLocalName() {
+    return null;
+  }
+
+  @Override
+  public String getLocalAddr() {
+    return null;
+  }
+
+  @Override
+  public int getLocalPort() {
+    return 0;
+  }
+
+  @Override
+  public ServletContext getServletContext() {
+    return null;
+  }
+
+  @Override
+  public AsyncContext startAsync() throws IllegalStateException {
+    return null;
+  }
+
+  @Override
+  public AsyncContext startAsync( ServletRequest servletRequest, ServletResponse servletResponse )
+    throws IllegalStateException {
+    return null;
+  }
+
+  @Override
+  public boolean isAsyncStarted() {
+    return false;
+  }
+
+  @Override
+  public boolean isAsyncSupported() {
+    return false;
+  }
+
+  @Override
+  public AsyncContext getAsyncContext() {
+    return null;
+  }
+
+  @Override
+  public DispatcherType getDispatcherType() {
+    return null;
+  }
+}

--- a/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpServletResponseForTesting.java
+++ b/pentaho5/src/test/java/pt/webdetails/cpk/testUtils/HttpServletResponseForTesting.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -22,10 +22,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Locale;
 
 public class HttpServletResponseForTesting implements HttpServletResponse {
   private OutputStream outputStream;
+  private int status;
 
   public HttpServletResponseForTesting( OutputStream outputStream ) {
     this.outputStream = outputStream;
@@ -54,6 +56,22 @@ public class HttpServletResponseForTesting implements HttpServletResponse {
 
   @Override public String encodeRedirectUrl( String s ) {
     return null;  //To change body of implemented methods use File | Settings | File Templates.
+  }
+
+  @Override public int getStatus() {
+    return this.status;
+  }
+
+  @Override public Collection<String> getHeaderNames() {
+    return null;
+  }
+
+  @Override public Collection<String> getHeaders( String name ) {
+    return null;
+  }
+
+  @Override public String getHeader( String name ) {
+    return null;
   }
 
   @Override public void sendError( int i, String s ) throws IOException {
@@ -93,7 +111,7 @@ public class HttpServletResponseForTesting implements HttpServletResponse {
   }
 
   @Override public void setStatus( int i ) {
-    //To change body of implemented methods use File | Settings | File Templates.
+    this.status = i;
   }
 
   @Override public void setStatus( int i, String s ) {

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <jackson-core-asl.version>1.8.2</jackson-core-asl.version>
     <jackson-mapper-asl.version>1.8.2</jackson-mapper-asl.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
-    <servlet-api.version>2.4</servlet-api.version>
+    <servlet-api.version>3.0.1</servlet-api.version>
     <jersey-core.version>1.16</jersey-core.version>
     <jersey-server.version>1.9.1</jersey-server.version>
     <powermock.version>1.6.3</powermock.version>
@@ -55,6 +55,7 @@
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.6</httpcore.version>
     <log4j.version>1.2.14</log4j.version>
+    <jsonassert.version>1.5.0</jsonassert.version>
   </properties>
 
   <dependencyManagement>
@@ -182,15 +183,8 @@
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
+        <artifactId>javax.servlet-api</artifactId>
         <version>${servlet-api.version}</version>
-        <scope>provided</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>


### PR DESCRIPTION
- Remove HttpServletResponse whenever possible and return equivalent javax.ws.rs.core.Response
- Upgrade servlet-api dependency version, from 2.4 to 3.0.1
- Checkstyle corrections
- Most of SonarLint broken rules fixes
- Unit Tests