### PR TITLE
[SPARKL-184] SPARKL: parallel requests to same endpoints could exchange parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ _version_ : Returns the plugin version (Defined on the plugins "version.xml" fil
 
 _getSitemapJson_ : Returns a [JSON](http://www.json.org/) with the plugins sitemap (Dashboards only!)
 
-_getElementsList_ : Returns a [JSON](http://www.json.org/) with the whole list of elements present on the plugin (dashboards and kettle endpoints)
+_elementsList_ : Returns a [JSON](http://www.json.org/) with the whole list of elements present on the plugin (dashboards and kettle endpoints)
 
 To perform a command:
 
@@ -306,7 +306,7 @@ Here's a list of stretch goals / nice to have
 
 ## Updates
 
-As the CPK framework or any of it's dependencies gets improved, the plugins
+As the CPK framework or any of its dependencies gets improved, the plugins
 themselves can't stay outdated. There will be a version information attached to
 the _CPK plugin version_ so that it's possible to upgrade to the latest version.
 

--- a/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
+++ b/core/src/main/java/pt/webdetails/cpk/CpkCoreService.java
@@ -76,6 +76,7 @@ public class CpkCoreService {
         final String url = getElementUrl( element, path );
 
         CpkUtils.redirect( response, url );
+        return;
       }
 
       final IAccessControl accessControl = environment.getAccessControl();

--- a/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleElementHelper.java
+++ b/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleElementHelper.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2022 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -207,21 +206,21 @@ public final class KettleElementHelper {
         return true;
       }
     }
+
     return false;
   }
 
-  public static boolean setParameterValue( NamedParams params, String paramName, String paramValue ) {
+  public static void setParameterValue( NamedParams params, String paramName, String paramValue ) {
     if ( !hasParameter( params, paramName ) ) {
       logger.warn( "Param '" + paramName + "' doesn't exist in the Kettle job/transformation" );
-      return false;
+      return;
     }
 
     try {
       params.setParameterValue( paramName, paramValue );
       logger.debug( "Set param '" + paramName + "' = '" + paramValue + "'" );
-      return true;
     } catch ( UnknownParamException e ) {
-      return false;
+      // Should not happen, given the above hasParameter() test.
     }
   }
 
@@ -386,25 +385,16 @@ public final class KettleElementHelper {
     return value;
   }
 
-
   /**
-   *
-   * @param kettleParams The parameters to set the value.
-   * @return The parameters that which value was set.
+   * @param params The target parameters to set.
+   * @param kettleParams The source parameters.
    */
-  public static Collection<String> setKettleParameterValues( NamedParams params, Map<String, String> kettleParams ) {
-    if ( kettleParams == null ) {
-      return Collections.emptySet();
-    }
-
-    LinkedList<String> setValueParamNames = new LinkedList<String>();
-    for ( Map.Entry<String, String> parameter : kettleParams.entrySet() ) {
-      if ( setParameterValue( params, parameter.getKey(), parameter.getValue() ) ) {
-        setValueParamNames.add( parameter.getKey() );
+  public static void setKettleParameterValues( NamedParams params, Map<String, String> kettleParams ) {
+    if ( kettleParams != null ) {
+      for ( Map.Entry<String, String> parameter : kettleParams.entrySet() ) {
+        setParameterValue( params, parameter.getKey(), parameter.getValue() );
       }
     }
-
-    return setValueParamNames;
   }
 
   /**
@@ -428,17 +418,6 @@ public final class KettleElementHelper {
       }
     }
     return parameters;
-  }
-
-  public static void clearParameters( NamedParams params, Collection<String> paramNames ) {
-    if ( paramNames == null ) {
-      return;
-    }
-
-    for ( String paramName : paramNames ) {
-      setParameterValue( params, paramName, null );
-      logger.debug( "Cleared request param '" + paramName + "'" );
-    }
   }
 
   // debug only

--- a/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleJobElement.java
+++ b/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleJobElement.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2022 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -72,14 +72,14 @@ public class KettleJobElement extends KettleElement<JobMeta> implements IDataSou
     logger.info( "Starting job '" + this.getName() + "' (" + this.meta.getName() + ")" );
     long start = System.currentTimeMillis();
 
+    // Clone meta so that parameters and any other state are isolated.
+    JobMeta executionMeta = (JobMeta) this.meta.clone();
+
     // add request parameters
-    Collection<String> setParameters = Collections.emptyList();
-    if ( kettleParameters != null ) {
-      setParameters = KettleElementHelper.setKettleParameterValues( this.meta, kettleParameters );
-    }
+    KettleElementHelper.setKettleParameterValues( executionMeta, kettleParameters );
 
     // create a new job
-    Job job = new Job( null, this.meta );
+    Job job = new Job( null, executionMeta );
 
     // start job thread and wait until it finishes
     job.start();
@@ -89,9 +89,6 @@ public class KettleJobElement extends KettleElement<JobMeta> implements IDataSou
     Result jobResult = this.getResult( job );
     KettleResult result = new KettleResult( jobResult );
     result.setKettleType( KettleResult.KettleType.JOB );
-
-    // clear request parameters
-    KettleElementHelper.clearParameters( this.meta, setParameters );
 
     long end = System.currentTimeMillis();
     this.logger.info( "Finished job '" + this.getName()

--- a/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java
+++ b/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java
@@ -14,7 +14,6 @@
 package pt.webdetails.cpk.elements.impl;
 
 import org.pentaho.di.core.Result;
-import org.pentaho.di.core.ResultFile;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -80,18 +79,14 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
     final List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>(  );
 
     try {
-      // clean?
-      this.meta.setResultRows( new ArrayList<RowMetaAndData>() );
-      this.meta.setResultFiles( new ArrayList<ResultFile>() );
+      // Clone meta so that parameters and any other state are isolated.
+      TransMeta executionMeta = (TransMeta) this.meta.clone();
 
       // add parameters
-      Collection<String> setParameters = Collections.emptyList();
-      if ( kettleParameters != null ) {
-        setParameters = KettleElementHelper.setKettleParameterValues( this.meta, kettleParameters );
-      }
+      KettleElementHelper.setKettleParameterValues( executionMeta, kettleParameters );
 
       // create a new transformation
-      Trans transformation = new Trans( this.meta );
+      Trans transformation = new Trans( executionMeta );
       transformation.prepareExecution( null ); // get the step threads after this line
 
       // get step to listen to written rows
@@ -118,10 +113,6 @@ public class KettleTransformationElement extends KettleElement<TransMeta> implem
       transformationResult.setRows( rows );
       result = new KettleResult( transformationResult );
       result.setKettleType( KettleResult.KettleType.TRANSFORMATION );
-
-      // clear request parameters
-      KettleElementHelper.clearParameters( meta, setParameters );
-
     } catch ( KettleException e ) {
       logger.debug( "KETTLE EXCEPTION: " + e, e );
     }

--- a/core/src/test/java/pt/webdetails/cpk/CpkCoreKettleElementTest.java
+++ b/core/src/test/java/pt/webdetails/cpk/CpkCoreKettleElementTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2022 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -81,7 +81,7 @@ public class CpkCoreKettleElementTest {
       final String paramName = json.getJSONArray( "metadata" ).getJSONObject( column ).getString( "colName" );
       final String paramValue = json.getJSONArray( "resultset" ).getJSONArray( row ).getString( column );
       if ( parameters.containsKey( paramName ) ) {
-        Assert.assertEquals( paramValue, parameters.get( paramName ) );
+        Assert.assertEquals( parameters.get( paramName ), paramValue );
       }
     }
   }


### PR DESCRIPTION
The **same, shared** `TransMeta`  instance was being used to set the parameters of each execution!

An `Element` is a shared thing, representing, in this context, a "transformation processor". It is created at plugin initialization.

The REST layer dispatches HTTP requests by calling into the determined, shared element’s `processRequest( ... )` method.
[Initially](https://github.com/webdetails/cpk/blob/9fb9c4e36af66b6137c511913b05f85635efdd4e/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java#L90), the parameters are set in TransMeta and a record is kept of those modified.
[Finally](https://github.com/webdetails/cpk/blob/9fb9c4e36af66b6137c511913b05f85635efdd4e/core/src/main/java/pt/webdetails/cpk/elements/impl/KettleTransformationElement.java#L123), the modified parameters are set to `null` (to avoid info leakage and cross-execution contamination).

This was however, not enough.