### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,11 +10,11 @@
   <parent>
     <groupId>org.pentaho.ctools</groupId>
     <artifactId>cpk-parent</artifactId>
-    <version>10.3.0.0-SNAPSHOT</version>
+    <version>11.0.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <encryption-support.version>10.3.0.0-SNAPSHOT</encryption-support.version>
+    <encryption-support.version>11.0.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -87,7 +86,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -108,13 +106,11 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -217,13 +213,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,13 +96,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,11 +10,11 @@
   <parent>
     <groupId>org.pentaho.ctools</groupId>
     <artifactId>cpk-parent</artifactId>
-    <version>11.0.0.0-SNAPSHOT</version>
+    <version>10.3.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <encryption-support.version>11.0.0.0-SNAPSHOT</encryption-support.version>
+    <encryption-support.version>10.3.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -74,6 +74,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -86,6 +87,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>${mockito-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -94,21 +96,25 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
+      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -211,11 +217,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,11 +10,11 @@
   <parent>
     <groupId>org.pentaho.ctools</groupId>
     <artifactId>cpk-parent</artifactId>
-    <version>11.0.0.0-SNAPSHOT</version>
+    <version>10.3.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <encryption-support.version>11.0.0.0-SNAPSHOT</encryption-support.version>
+    <encryption-support.version>10.3.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -70,6 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
@@ -105,6 +106,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>${mockito-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -113,21 +115,25 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
+      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -226,11 +232,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,11 +10,11 @@
   <parent>
     <groupId>org.pentaho.ctools</groupId>
     <artifactId>cpk-parent</artifactId>
-    <version>10.3.0.0-SNAPSHOT</version>
+    <version>11.0.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <encryption-support.version>10.3.0.0-SNAPSHOT</encryption-support.version>
+    <encryption-support.version>11.0.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
@@ -106,7 +105,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -127,13 +125,11 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -232,13 +228,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pentaho5/pom.xml
+++ b/pentaho5/pom.xml
@@ -129,13 +129,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pentaho5/pom.xml
+++ b/pentaho5/pom.xml
@@ -142,13 +142,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,13 +200,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -211,13 +211,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -213,13 +213,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.16</version>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This pull request makes a minor update to the pom.xml file. It replaces hardcoded versions of the byte-buddy and byte-buddy-agent test dependencies with the ${byte-buddy.version} property, making version management more flexible.